### PR TITLE
Replace 'appending div' with html canvas renderer

### DIFF
--- a/src/js/frameplayer.js
+++ b/src/js/frameplayer.js
@@ -38,21 +38,7 @@ var FramePlayer = function(el, options){
 
     if(this.controls){ this.createControlsBar(); }
 
-    // this.initialize();
-};
-
-FramePlayer.prototype.initialize = function() {
     this.initializeRequestAnimationFrame();
-    // this.runCanvasRenderer();
-};
-
-FramePlayer.prototype.runCanvasRenderer = function() {
-    var player = this;
-    var processFrame = function() {
-        window.requestAnimationFrame(processFrame);
-    };
-
-    window.requestAnimationFrame(processFrame);
 };
 
 FramePlayer.prototype.render = function(jsonVideoFile, player) {
@@ -70,7 +56,6 @@ FramePlayer.prototype.render = function(jsonVideoFile, player) {
         container.setAttribute('class', 'fp-container');
         container.style.width = player.width;
         container.style.height = player.height;
-        // container.appendChild(img);
 
         player.canvas = document.createElement('canvas');
         player.context = player.canvas.getContext('2d');
@@ -243,9 +228,7 @@ FramePlayer.prototype.getFile = function(src, callback){
 FramePlayer.prototype.initializeRequestAnimationFrame = function() {
     // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
     // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating
-     
     // requestAnimationFrame polyfill by Erik Möller. fixes from Paul Irish and Tino Zijdel
-     
     // MIT license
 
     var lastTime = 0;


### PR DESCRIPTION
This is a proposal for performances, to avoid the write the DOM for every images, that is very expensive and slow process for every browser, because the HTML canvas is [fully supported](http://caniuse.com/#feat=canvas) by all the *relevant* browsers. To support IE8 can be an alternative to fallback to the 'appendind div' approach currently used.

- swapped the 'appending div' rendering of the video with rendering the video in a canvas
- added request animation frame polyfill
- left availability to control the frame rate (integrating it with the request animation frame)

*NOTE*: css filters are not working, I didn't not removed because if the PR will get accepted and receive positive feedback on the proposal, I'll move forward to implement the filters directly in cavas